### PR TITLE
Initialize cookie variable

### DIFF
--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -346,6 +346,7 @@ def query_ldap_with_paging(ldap_client, base_dn, search_filter, attributes, outp
        By default Active Directory will return 1,000 results per query before it errors out."""
 
     # Method Variables
+    cookie=''
     more_pages = True
     output_array = deque()
 


### PR DESCRIPTION
Running the script as
`python ad-ldap-enum.py -l 10.0.64.218 -d myDomain.com -v -n`
would abort with the following error message
![captura de tela 2018-12-23 as 01 27 48](https://user-images.githubusercontent.com/9597536/50380600-28ea3280-0653-11e9-8ea2-7acf862dd6a2.png)
