### PR TITLE
 Adding Support for Computer SPNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Authentication Parameters:
 ### Assorted Links
 * [Membership Ranges in Active Directory](https://msdn.microsoft.com/en-us/library/Aa367017)
 * [Active Directory Paging](https://technet.microsoft.com/en-us/library/Cc755809(v=WS.10).aspx#w2k3tr_adsrh_how_lhjt)
+* [Commonly Used SPNs](https://adsecurity.org/?page_id=183)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Server Parameters:
   -d DOMAIN, --domain DOMAIN                        Authentication account's FQDN. If an alternative domain is not specified this will be also used as the Base DN for searching LDAP.
   -a ALT_DOMAIN, --alt-domain ALT_DOMAIN            Alternative FQDN to use as the Base DN for searching LDAP.
   -e, --nested                                      Expand nested groups.
+  -S, --spns                                        Search for SPNs for each given computer acount
 
 Authentication Parameters:
   -n, --null                                        Use a null binding to authenticate to LDAP.

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -130,7 +130,6 @@ class ADComputer(object):
 
     def __init__(self, retrieved_attributes):
 
-
         if 'distinguishedName' in retrieved_attributes:
             self.distinguished_name = retrieved_attributes['distinguishedName'][0]
         if 'sAMAccountName' in retrieved_attributes:
@@ -407,7 +406,6 @@ def get_membership_with_ranges(ldap_client, base_dn, group_dn):
 # We need to parse out the SPNs list for each host in order to sort them out for file write and easier useage.
 def parse_spns(service_principle_names):
 
-
     temp_sql_spns = []
     sql_spn_strings = ['MSSQLSvc', 'gateway', 'hbase', 'HBase', 'hdb', 'hdfs', 'hive', 'Kafka', 'mongod', 'mongos', 'MSOLAPSvc', 'MSSQL', 'oracle', 'postgres']
     temp_ra_spns = []
@@ -444,9 +442,6 @@ def parse_spns(service_principle_names):
             temp_other_spns.append(spn)
 
     return [temp_sql_spns, temp_ra_spns, temp_share_spns, temp_mail_spns, temp_auth_spns, temp_backup_spns, temp_management_spns, temp_other_spns]
-
-
-
 
 if __name__ == '__main__':
     start_time = datetime.datetime.now()

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -127,7 +127,6 @@ class ADComputer(object):
     operating_system_version = ''
     service_principal_names = []
 
-
     def __init__(self, retrieved_attributes):
 
         if 'distinguishedName' in retrieved_attributes:

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -453,7 +453,7 @@ if __name__ == '__main__':
     server_group.add_argument('-d', '--domain', required=True, dest='domain', help='Authentication account\'s FQDN. If an alternative domain is not specified this will be also used as the Base DN for searching LDAP.')
     server_group.add_argument('-a', '--alt-domain', dest='alt_domain', help='Alternative FQDN to use as the Base DN for searching LDAP.')
     server_group.add_argument('-e', '--nested', dest='nested_groups', action='store_true', help='Expand nested groups.')
-    server_group.add_argument('-S', '--spns', dest='spns', action='store_true', help='Search for SPNs for each even computer acount')
+    server_group.add_argument('-S', '--spns', dest='spns', action='store_true', help='Search for SPNs for each given computer acount')
     authentication_group = parser.add_argument_group('Authentication Parameters')
     authentication_group.add_argument('-n', '--null', dest='null_session', action='store_true', help='Use a null binding to authenticate to LDAP.')
     authentication_group.add_argument('-s', '--secure', dest='secure_comm', action='store_true', help='Connect to LDAP over SSL')


### PR DESCRIPTION
Added an additional option -S, --spns to collect SPNs (in relation to #15 ) which if included also queries domain computers for 'servicePrincipalName'. The response is then parsed by a new function 'parse_spns' which attempts to group spns into categories based on commonly known/seen SPN strings. These categories are then written to the standard Domain Computers output file as additional columns, wherein the <spn>/<hostname> is included as a comma separated list (or blank if no matches were found), in each given given hosts category cell.