### PR TITLE
Ldap3 Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'co
 ### Modification
 If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
 1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
-    a. Please note that modifying the group output may be a little more difficult.
+  * Please note that modifying the group output may be a little more difficult.
 2. Append the attribute to the applicable object list within `user_attributes`, `group_attributes`, or `computer_attributes`
 3. Update the object's class to have a default value (i.e., `distinguished_name = ''`)
 4. Update the object's class to have the `__init__` function parse the retrieved attribute

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ An LDAP based Active Directory object (users, groups, and computers) enumeration
 ### About
 
 ad-ldap-enum is a Python script developed to collect users/computers and their group memberships from Active Directory. In large Active Directory environments, tools such as NBTEnum were not performing fast enough. By executing LDAP queries against a domain controller, ad-ldap-enum is able to target specific Active Directory attributes and quickly build out group membership.
-ad-ldap-enum outputs three tab delimited files `Domain_Group_Membership.csv`, `Extended_Domain_User_Information.csv`, and `Extended_Domain_Computer_Information.csv`. The first file contains users, computers, groups, and their memberships. The second file contains users and extra information about the users from Active Directory (e.g. a user's home folder or email address). The third file contains computers in the Domain Computers group and extra information about them from Active Directory (e.g. operating system type and service pack version).
+ad-ldap-enum outputs three tab delimited files:
+- `Domain_Group_Membership.csv`
+- `Extended_Domain_User_Information.csv`
+- `Extended_Domain_Computer_Information.csv`
+
+The first file contains users, computers, groups, and their memberships. The second file contains users and extra information about the users from Active Directory (e.g. a user's home folder or email address). The third file contains computers in the 'Domain Computers' group and extra information about them from Active Directory (e.g. operating system type and service pack version).
 ad-ldap-enum supports both authenticated and unauthenticated LDAP connections. Additionally, ad-ldap-enum can process nested groups and display a user's actual group membership.
 This tool also supports password and Pass-the-Hash (PtH) `LM:NTLM` style authentication.
 ad-ldap-enum also supports LDAP over SSL/TLS connections, IPv4, and IPv6 networks.
@@ -78,10 +83,7 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -p 'P@ssw
 ```
 python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -s -u 'Administrator' -p 'aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0'
 ```
-**Kerberos authentication with alternative domain**
-```
-python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'contoso.local'
-```
+
 ### Modification
 If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
 1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'co
 ### Modification
 If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
 1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
-  * Please note that modifying the group output may be a little more difficult.
+   * Please note that modifying the group output may be a little more difficult.
 2. Append the attribute to the applicable object list within `user_attributes`, `group_attributes`, or `computer_attributes`
 3. Update the object's class to have a default value (i.e., `distinguished_name = ''`)
 4. Update the object's class to have the `__init__` function parse the retrieved attribute

--- a/README.md
+++ b/README.md
@@ -23,18 +23,24 @@ Additionally, this tool has been built and tested against Python v3.10 on both K
 ### Usage
 Please see the tool's help menu below:
 ```
-usage: ad-ldap-enum.py [-h] [-s] [-t TIMEOUT] [-ql QUERY_LIMIT]
+usage: ad-ldap-enum.py [-h] (-n | -u USERNAME | -dn DISTINGUISHED_NAME)
+                       [-p PASSWORD] [-P] [-s] [-t TIMEOUT] [-ql QUERY_LIMIT]
                        [--verbosity {OFF,ERROR,BASIC,PROTOCOL,NETWORK,EXTENDED}]
-                       [-lf LOG_FILE] [-p PASSWORD] [-P] [-o FILENAME_PREPEND]
-                       [--legacy] [-4] [-6]
-                       (-n | -u USERNAME | -dn DISTINGUISHED_NAME) -l
-                       LDAP_SERVER [--port PORT] -d DOMAIN [-a ALT_DOMAIN]
-                       [-e]
+                       [--legacy] [-x] [-o FILENAME_PREPEND] -l LDAP_SERVER
+                       [--port PORT] -d DOMAIN [-a ALT_DOMAIN] [-e] [-4] [-6]
 
 Active Directory LDAP Enumerator
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
+  -n, --null            Use a null binding to authenticate to LDAP.
+  -u USERNAME, --username USERNAME
+                        Authentication account's username.
+  -dn DISTINGUISHED_NAME, --distinguished_name DISTINGUISHED_NAME
+                        Authentication account's distinguished name
+  -p PASSWORD, --password PASSWORD
+                        Authentication account's password or "LM:NTLM".
+  -P, --prompt          Prompt for the authentication account's password.
   -s, --secure          Connect to LDAP over SSL/TLS
   -t TIMEOUT, --timeout TIMEOUT
                         LDAP server connection timeout in seconds
@@ -42,35 +48,25 @@ options:
                         LDAP server query timeout in seconds
   --verbosity {OFF,ERROR,BASIC,PROTOCOL,NETWORK,EXTENDED}
                         Log file LDAP verbosity level
-  -lf LOG_FILE, --log_file LOG_FILE
-                        Log text file path
-  -p PASSWORD, --password PASSWORD
-                        Authentication account's password or "LM:NTLM".
-  -P, --prompt          Prompt for the authentication account's password.
-  -o FILENAME_PREPEND, --prepend FILENAME_PREPEND
-                        Prepend a string to all output file names' CSV.
   --legacy              Gather and output attributes using the old python-ldap
                         package .tsv format (will be deprecated)
-  -4, --inet            Only use IPv4 networking (default prefer IPv4)
-  -6, --inet6           Only use IPv6 networking (default prefer IPv4)
-  -n, --null            Use a null binding to authenticate to LDAP.
-  -u USERNAME, --username USERNAME
-                        Authentication account's username.
-  -dn DISTINGUISHED_NAME, --distinguished_name DISTINGUISHED_NAME
-                        Authentication account's distinguished name
+  -x, --excel           Output an .XLSX with all 3 sheets: users/groups/computers
+  -o FILENAME_PREPEND, --prepend FILENAME_PREPEND
+                        Prepend a string to all output file names.
 
 Server Parameters:
   -l LDAP_SERVER, --server LDAP_SERVER
                         FQDN/IP address of the LDAP server.
   --port PORT           TCP port of the LDAP server.
   -d DOMAIN, --domain DOMAIN
-                        Authentication account's domain. If an alternative
-                        domain is not specified, this will be also used as the
-                        Base DN for searching LDAP.
+                        Authentication account's domain. If an alternative domain
+                        is not specified, this will be also used as the Base DN
+                        for searching LDAP.
   -a ALT_DOMAIN, --alt-domain ALT_DOMAIN
-                        Alternative FQDN to use as the Base DN for searching
-                        LDAP.
+                        Alternative FQDN to use as the Base DN for searching LDAP.
   -e, --nested          Expand nested groups.
+  -4, --inet            Only use IPv4 networking (default prefer IPv4)
+  -6, --inet6           Only use IPv6 networking (default prefer IPv4)
 ```
 ### Example
 Please see some examples below:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'co
 ### Modification
 If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
 1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
-  1. Please note that modifying the group output may be a little more difficult.
+   1. Please note that modifying the group output may be a little more difficult.
 2. Append the attribute to the applicable object list within `user_attributes`, `group_attributes`, or `computer_attributes`
 3. Update the object's class to have a default value (i.e., `distinguished_name = ''`)
 4. Update the object's class to have the `__init__` function parse the retrieved attribute

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'co
 ### Modification
 If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
 1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
-   * Please note that modifying the group output may be a little more difficult.
+  1. Please note that modifying the group output may be a little more difficult.
 2. Append the attribute to the applicable object list within `user_attributes`, `group_attributes`, or `computer_attributes`
 3. Update the object's class to have a default value (i.e., `distinguished_name = ''`)
 4. Update the object's class to have the `__init__` function parse the retrieved attribute

--- a/README.md
+++ b/README.md
@@ -81,8 +81,23 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -s -u 'Administrator' -p 'aa
 ```
 python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'contoso.local'
 ```
+### Modification
+If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
+1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
+  a. Please note that modifying the group output may be a little more difficult.
+2. Append the attribute to the applicable object list within `user_attributes`, `group_attributes`, or `computer_attributes`
+3. Update the object's class to have a default value (i.e., `distinguished_name = ''`)
+4. Update the object's class to have the `__init__` function parse the retrieved attribute
+5. Update the object's output section to include appending the new attribute header and value
+### Planned Features
+We should plan to include the following features moving forward:
+- Kerberos authentication (preferably not using the Impacket suite so that the tool can be OS agnostic)
+- LDAP signing
+- LDAP channel binding
+Pull requests are welcome!
 ### Assorted Links
 Please see some assorted reference links and similar projects:
+- [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
 - [Membership Ranges in Active Directory](https://msdn.microsoft.com/en-us/library/Aa367017)
 - [Active Directory Paging](https://technet.microsoft.com/en-us/library/Cc755809(v=WS.10).aspx#w2k3tr_adsrh_how_lhjt)
 - [LDAPDomainDumper](https://github.com/dirkjanm/ldapdomaindump)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Server Parameters:
 ```
 ### Example
 Please see some examples below:
+
 **Password authentication**
 ```
 python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -p 'P@ssw0rd' -o 'ad-ldap-enum_2' --verbosity BASIC -lf 'ad-ldap-enum_Log.txt'
@@ -84,7 +85,7 @@ python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'co
 ### Modification
 If you would like to add more attributes to the non-legacy version, the following steps can be quickly added:
 1. Find the attribute's formatted name at [All Active Directory Attributes](https://learn.microsoft.com/en-us/windows/win32/adschema/attributes-all)
-  a. Please note that modifying the group output may be a little more difficult.
+    a. Please note that modifying the group output may be a little more difficult.
 2. Append the attribute to the applicable object list within `user_attributes`, `group_attributes`, or `computer_attributes`
 3. Update the object's class to have a default value (i.e., `distinguished_name = ''`)
 4. Update the object's class to have the `__init__` function parse the retrieved attribute
@@ -94,6 +95,8 @@ We should plan to include the following features moving forward:
 - Kerberos authentication (preferably not using the Impacket suite so that the tool can be OS agnostic)
 - LDAP signing
 - LDAP channel binding
+- ObjectSID retrieval
+
 Pull requests are welcome!
 ### Assorted Links
 Please see some assorted reference links and similar projects:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you would like to add more attributes to the non-legacy version, the followin
 5. Update the object's output section to include appending the new attribute header and value
 ### Planned Features
 We should plan to include the following features moving forward:
-- Kerberos authentication (preferably not using the Impacket suite so that the tool can be OS agnostic)
+- Kerberos authentication (preferably not using the Impacket suite so that the tool can be OS-agnostic)
 - LDAP signing
 - LDAP channel binding
 - ObjectSID retrieval

--- a/README.md
+++ b/README.md
@@ -1,49 +1,90 @@
 # ad-ldap-enum
-An LDAP based Active Directory user and group enumeration tool
+
+An LDAP based Active Directory object (users, groups, and computers) enumeration tool. 
 
 ### About
-ad-ldap-enum is a Python script that was developed to discover users and their group memberships from Active Directory. In large Active Directory environments, tools such as NBTEnum were not performing fast enough. By executing LDAP queries against a domain controller, ad-ldap-enum is able to target specific Active Directory attributes and build out group membership quickly.
 
-ad-ldap-enum outputs three tab delimited files 'Domain Group Membership.tsv', 'Extended Domain User Information.tsv', and 'Extended Domain Computer Information.tsv'. The first file contains users, computers, groups, and their memberships. The second file contains users and extra information about the users from Active Directory (e.g. a user's home folder or email address). The third file contains devices in the Domain Computers group and extra information about them from Active Directory (e.g. operating system type and service pack version).
-
+ad-ldap-enum is a Python script developed to collect users/computers and their group memberships from Active Directory. In large Active Directory environments, tools such as NBTEnum were not performing fast enough. By executing LDAP queries against a domain controller, ad-ldap-enum is able to target specific Active Directory attributes and quickly build out group membership.
+ad-ldap-enum outputs three tab delimited files `Domain_Group_Membership.csv`, `Extended_Domain_User_Information.csv`, and `Extended_Domain_Computer_Information.csv`. The first file contains users, computers, groups, and their memberships. The second file contains users and extra information about the users from Active Directory (e.g. a user's home folder or email address). The third file contains computers in the Domain Computers group and extra information about them from Active Directory (e.g. operating system type and service pack version).
 ad-ldap-enum supports both authenticated and unauthenticated LDAP connections. Additionally, ad-ldap-enum can process nested groups and display a user's actual group membership.
-
+This tool also supports password and Pass-the-Hash (PtH) `LM:NTLM` style authentication with the soon to be created Kerberos authentication too.
+ad-ldap-enum also supports LDAP over SSL/TLS connections and planned to support LDAP signing requirements too in the coming future. IPv4 and IPv6 networking is also supported as needed.
 ### Requirements
-The package [python-ldap](http://www.python-ldap.org/index.html) is required for the script to execute. This can be installed with the following command:
+The package primarily uses the [ldap3](https://ldap3.readthedocs.io/en/latest/) Python package to execute the LDAP connections and queries. To install all requirements, please run the below command:
 ```
-sudo apt-get install libsasl2-dev libldap2-dev libssl-dev
-pip install python-ldap
-````
-
-Additionally, this tools has been built and tested against Python v3.8.5 and python-ldap v3.2.0
-
+python -m pip install -r 'requirements.txt'
+```
+Additionally, this tool has been built and tested against Python v3.10 on both Kali Linux and Windows 10. Regardless, this tool aims to be OS-agnostic working on both UNIX/Linux systems and Windows. Furthermore, Python 2.X support will not be added.
 ### Usage
+Please see the tool's help menu below:
 ```
-ad-ldap-enum.py [-h] -l LDAP_SERVER -d DOMAIN [-a ALT_DOMAIN] [-e] [-n] [-u USERNAME] [-p PASSWORD] [-v]
+usage: ad-ldap-enum.py [-h] [-s] [-t TIMEOUT] [-ql QUERY_LIMIT]
+                       [--verbosity {OFF,ERROR,BASIC,PROTOCOL,NETWORK,EXTENDED}]
+                       [-lf LOG_FILE] [-p PASSWORD] [-P] [-o FILENAME_PREPEND]
+                       [--legacy] [-4] [-6]
+                       (-n | -u USERNAME | -dn DISTINGUISHED_NAME) -l
+                       LDAP_SERVER [--port PORT] -d DOMAIN [-a ALT_DOMAIN]
+                       [-e]
 
 Active Directory LDAP Enumerator
 
-optional arguments:
-  -h, --help                                        show this help message and exit
-  -v, --verbose                                     Display debugging information.
-  -o FILENAME_PREPEND, --prepend FILENAME_PREPEND   Prepend a string to all output file names.
+options:
+  -h, --help            show this help message and exit
+  -s, --secure          Connect to LDAP over SSL/TLS
+  -t TIMEOUT, --timeout TIMEOUT
+                        LDAP server connection timeout in seconds
+  -ql QUERY_LIMIT, --query_limit QUERY_LIMIT
+                        LDAP server query timeout in seconds
+  --verbosity {OFF,ERROR,BASIC,PROTOCOL,NETWORK,EXTENDED}
+                        Log file LDAP verbosity level
+  -lf LOG_FILE, --log_file LOG_FILE
+                        Log text file path
+  -p PASSWORD, --password PASSWORD
+                        Authentication account's password or "LM:NTLM".
+  -P, --prompt          Prompt for the authentication account's password.
+  -o FILENAME_PREPEND, --prepend FILENAME_PREPEND
+                        Prepend a string to all output file names' CSV.
+  --legacy              Gather and output attributes using the old python-ldap
+                        package .tsv format (will be deprecated)
+  -4, --inet            Only use IPv4 networking (default prefer IPv4)
+  -6, --inet6           Only use IPv6 networking (default prefer IPv4)
+  -n, --null            Use a null binding to authenticate to LDAP.
+  -u USERNAME, --username USERNAME
+                        Authentication account's username.
+  -dn DISTINGUISHED_NAME, --distinguished_name DISTINGUISHED_NAME
+                        Authentication account's distinguished name
 
 Server Parameters:
-  -l LDAP_SERVER, --server LDAP_SERVER              IP address of the LDAP server.
-  -d DOMAIN, --domain DOMAIN                        Authentication account's FQDN. If an alternative domain is not specified this will be also used as the Base DN for searching LDAP.
-  -a ALT_DOMAIN, --alt-domain ALT_DOMAIN            Alternative FQDN to use as the Base DN for searching LDAP.
-  -e, --nested                                      Expand nested groups.
-
-Authentication Parameters:
-  -n, --null                                        Use a null binding to authenticate to LDAP.
-  -s, --secure                                      Connect to LDAP over SSL
-  -u USERNAME, --username USERNAME                  Authentication account's username.
-  -p PASSWORD, --password PASSWORD                  Authentication account's password.
+  -l LDAP_SERVER, --server LDAP_SERVER
+                        FQDN/IP address of the LDAP server.
+  --port PORT           TCP port of the LDAP server.
+  -d DOMAIN, --domain DOMAIN
+                        Authentication account's domain. If an alternative
+                        domain is not specified, this will be also used as the
+                        Base DN for searching LDAP.
+  -a ALT_DOMAIN, --alt-domain ALT_DOMAIN
+                        Alternative FQDN to use as the Base DN for searching
+                        LDAP.
+  -e, --nested          Expand nested groups.
 ```
-
 ### Example
-```python ad-ldap-enum.py -d contoso.com -l 10.0.0.1 -u Administrator -p P@ssw0rd```
-
+Please see some examples below:
+**Password authentication**
+```
+python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -p 'P@ssw0rd' -o 'ad-ldap-enum_2' --verbosity BASIC -lf 'ad-ldap-enum_Log.txt'
+```
+**Pass-the-Hash LDAPS authentication**
+```
+python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -s -u 'Administrator' -p 'aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0'
+```
+**Kerberos authentication with alternative domain**
+```
+python 'ad-ldap-enum.py' -d contoso.com -l 10.0.0.1 -u 'Administrator' -k -a 'contoso.local'
+```
 ### Assorted Links
-* [Membership Ranges in Active Directory](https://msdn.microsoft.com/en-us/library/Aa367017)
-* [Active Directory Paging](https://technet.microsoft.com/en-us/library/Cc755809(v=WS.10).aspx#w2k3tr_adsrh_how_lhjt)
+Please see some assorted reference links and similar projects:
+- [Membership Ranges in Active Directory](https://msdn.microsoft.com/en-us/library/Aa367017)
+- [Active Directory Paging](https://technet.microsoft.com/en-us/library/Cc755809(v=WS.10).aspx#w2k3tr_adsrh_how_lhjt)
+- [LDAPDomainDumper](https://github.com/dirkjanm/ldapdomaindump)
+- [ADRecon](https://github.com/adrecon/ADRecon)
+- [ADSearch](https://github.com/tomcarver16/ADSearch)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ An LDAP based Active Directory object (users, groups, and computers) enumeration
 ad-ldap-enum is a Python script developed to collect users/computers and their group memberships from Active Directory. In large Active Directory environments, tools such as NBTEnum were not performing fast enough. By executing LDAP queries against a domain controller, ad-ldap-enum is able to target specific Active Directory attributes and quickly build out group membership.
 ad-ldap-enum outputs three tab delimited files `Domain_Group_Membership.csv`, `Extended_Domain_User_Information.csv`, and `Extended_Domain_Computer_Information.csv`. The first file contains users, computers, groups, and their memberships. The second file contains users and extra information about the users from Active Directory (e.g. a user's home folder or email address). The third file contains computers in the Domain Computers group and extra information about them from Active Directory (e.g. operating system type and service pack version).
 ad-ldap-enum supports both authenticated and unauthenticated LDAP connections. Additionally, ad-ldap-enum can process nested groups and display a user's actual group membership.
-This tool also supports password and Pass-the-Hash (PtH) `LM:NTLM` style authentication with the soon to be created Kerberos authentication too.
-ad-ldap-enum also supports LDAP over SSL/TLS connections and planned to support LDAP signing requirements too in the coming future. IPv4 and IPv6 networking is also supported as needed.
+This tool also supports password and Pass-the-Hash (PtH) `LM:NTLM` style authentication.
+ad-ldap-enum also supports LDAP over SSL/TLS connections, IPv4, and IPv6 networks.
 ### Requirements
 The package primarily uses the [ldap3](https://ldap3.readthedocs.io/en/latest/) Python package to execute the LDAP connections and queries. To install all requirements, please run the below command:
 ```
 python -m pip install -r 'requirements.txt'
 ```
-Additionally, this tool has been built and tested against Python v3.10 on both Kali Linux and Windows 10. Regardless, this tool aims to be OS-agnostic working on both UNIX/Linux systems and Windows. Furthermore, Python 2.X support will not be added.
+Additionally, this tool has been built and tested against Python v3.10 on both Kali Linux and Windows 10. Regardless, this tool aims to be OS-agnostic working on both UNIX/Linux systems and Windows. Furthermore, Python 2.X will not be supported.
 ### Usage
 Please see the tool's help menu below:
 ```

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -284,9 +284,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                 tmp_element = ''
                 for x, binary_string in enumerate(temp_list_a[1:]):
                     binary_string = str(binary_string).strip()
-                    if binary_string[:2] == "b'":
+                    if binary_string[:2] == "b'" or binary_string[:2] == 'b"':
                         binary_string = binary_string[2:]
-                    if binary_string[-1:] == "'":
                         binary_string = binary_string[:-1]
                     if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
                         continue
@@ -337,9 +336,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                 tmp_element = ''
                 for x, binary_string in enumerate(temp_list_b):
                     binary_string = str(binary_string).strip()
-                    if binary_string[:2] == "b'":
+                    if binary_string[:2] == "b'" or binary_string[:2] == 'b"':
                         binary_string = binary_string[2:]
-                    if binary_string[-1:] == "'":
                         binary_string = binary_string[:-1]
                     if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
                         continue
@@ -369,9 +367,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
             tmp_element = ''
             for x, binary_string in enumerate(element):
                 binary_string = str(binary_string).strip()
-                if binary_string[:2] == "b'":
+                if binary_string[:2] == "b'" or binary_string[:2] == 'b"':
                     binary_string = binary_string[2:]
-                if binary_string[-1:] == "'":
                     binary_string = binary_string[:-1]
                 if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
                     continue
@@ -478,7 +475,9 @@ def parse_spns(service_principle_names):
     temp_other_spns = []
 
     for spn in service_principle_names:
-        spn = str(spn).lstrip("b'").rstrip("'")
+        if spn[:2] == "b'" or spn[:2] == 'b"':
+            spn = spn[2:]
+            spn = spn[:-1]
         if spn.split('/')[0] in sql_spn_strings:
             temp_sql_spns.append(spn)
         elif spn.split('/')[0] in ra_spn_strings:

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -523,6 +523,7 @@ if __name__ == '__main__':
     parser.add_argument('-ql', '--query_limit', type=int, default=30, help='LDAP server query timeout in seconds')
     parser.add_argument('--verbosity', default='ERROR', choices=['OFF', 'ERROR', 'BASIC', 'PROTOCOL', 'NETWORK', 'EXTENDED'], help='Log file LDAP verbosity level')
     parser.add_argument('-lf', '--log_file', help='Log text file path')
+    parser.add_argument('-k', '--kerberos', help='Use Kerberos authentication')
     parser.add_argument('-p', '--password', help='Authentication account\'s password or "LM:NTLM".')
     parser.add_argument('-P', '--prompt', dest='password_prompt', action='store_true', help='Prompt for the authentication account\'s password.')
     parser.add_argument('-o', '--prepend', dest='filename_prepend', default='ad-ldap-enum_', help='Prepend a string to all output file names\' CSV.')
@@ -546,9 +547,14 @@ if __name__ == '__main__':
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
-   # If --prompt then overwrite args.password now
+    # If --prompt then overwrite args.password now
     if args.password_prompt is True or (not args.password and not args.null_session):
         args.password = getpass()
+
+    # If Kerberos, require user
+    if args.kerberos and (not args.user or not args.domain):
+        print('[e] A user and domain must both be specified with Kerberos authentication usage.') 
+        exit(1)
 
     # Set Logger format
     if args.verbosity != 'OFF' or args.log_file:
@@ -608,12 +614,14 @@ if __name__ == '__main__':
         print('[-] Connecting to LDAP server at "%s:%i"...' % (args.ldap_server, args.port))
 
         # LDAP Authentication
-        if args.null_session is True:
+        if args.null_session:
             ldap_client = ldap3.Connection(ldap_client, read_only=True, raise_exceptions=True, receive_timeout=args.timeout, auto_range=True, return_empty_attributes=False)
         elif args.distinguished_name:
             ldap_client = ldap3.Connection(ldap_client, user=args.distinguished_name, password=args.password, read_only=True, raise_exceptions=True, receive_timeout=args.timeout, auto_range=True, return_empty_attributes=False)
+        elif args.kerberos:
+            ldap_client = ldap3.Connection(ldap_client, user=args.domain + '/' + args.username, read_only=True, raise_exceptions=True, receive_timeout=args.timeout, auto_range=True, return_empty_attributes=False, authentication=ldap3.SASL, sasl_mechanism=ldap3.KERBEROS)
         else:
-            ldap_client = ldap3.Connection(ldap_client, user=args.domain + '\\' + args.username, password=args.password, read_only=True, raise_exceptions=True, authentication=ldap3.NTLM, receive_timeout=args.timeout, auto_range=True, return_empty_attributes=False)
+            ldap_client = ldap3.Connection(ldap_client, user=args.domain + '\\' + args.username, password=args.password, sasl_credentials=(ldap3.ReverseDnsSetting.OPTIONAL_RESOLVE_ALL_ADDRESSES,), read_only=True, raise_exceptions=True, authentication=ldap3.NTLM, receive_timeout=args.timeout, auto_range=True, return_empty_attributes=False)
         ldap_client.bind()
     except ldap3.core.exceptions.LDAPOperationsErrorResult as e:
         if 'perform this operation a successful bind' in str(e):

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -645,7 +645,7 @@ if __name__ == '__main__':
         ldap_client.bind()
     except ldap3.core.exceptions.LDAPOperationsErrorResult as e:
         if 'perform this operation a successful bind' in str(e):
-            print('[e] Although an initial connection was made, a successful bind did not occur.')
+            print('[e] Although an initial connection was made, a bind failed to connect.')
         logging.error(traceback.format_exc())
         exit(1)
     except ldap3.core.exceptions.LDAPSocketOpenError as e:

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -244,7 +244,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
     # TODO: This could create output duplicates. It should be fixed at some point.
     # Add users if they have the group set as their primary ID as the group.
     # Additionally, add extended domain user information to a text file.
-    user_information_filename = '{0}Extended_Domain_User_Information.csv'.format(args.filename_prepend).strip()
+    user_information_filename = '{0}Extended_Domain_User_Information.csv'.format(args.filename_prepend.strip())
     if legacy:
         user_information_filename = user_information_filename.replace('csv', 'tsv')
     with open(user_information_filename, 'w') as user_information_file:
@@ -290,6 +290,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                         binary_string = binary_string[:-1]
                     if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
                         continue
+                    if not legacy and '"' in binary_string:
+                        binary_string = binary_string.replace('"', '*DOUBLEQUOTE*')
                     if not legacy and ',' in binary_string:
                         binary_string = '"' + binary_string + '"'
                     if x == len(temp_list_a[1:])-1 :
@@ -302,7 +304,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                 user_information_file.write(tmp_element)
 
     # Write Domain Computer Information
-    computer_information_filename = '{0}Extended_Domain_Computer_Information.csv'.format(args.filename_prepend).strip()
+    computer_information_filename = '{0}Extended_Domain_Computer_Information.csv'.format(args.filename_prepend.strip())
     if legacy:
         computer_information_filename = computer_information_filename.replace('csv', 'tsv')
     with open(computer_information_filename, 'w') as computer_information_file:
@@ -342,6 +344,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                         binary_string = binary_string[:-1]
                     if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
                         continue
+                    if not legacy and '"' in binary_string:
+                        binary_string = binary_string.replace('"', '*DOUBLEQUOTE*')
                     if not legacy and ',' in binary_string:
                         binary_string = '"' + binary_string + '"'
                     if x == len(temp_list_b)-1 :
@@ -354,7 +358,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                 _output_dictionary.append(temp_list_a)
 
     # Write Group Memberships
-    group_membership_filename = '{0}Domain_Group_Membership.csv'.format(args.filename_prepend).strip()
+    group_membership_filename = '{0}Domain_Group_Membership.csv'.format(args.filename_prepend.strip())
     if legacy:
         group_membership_filename = group_membership_filename.replace('csv', 'tsv')
     with open(group_membership_filename, 'w') as group_membership_file:
@@ -373,6 +377,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                     binary_string = binary_string[:-1]
                 if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
                     continue
+                if not legacy and '"' in binary_string:
+                        binary_string = binary_string.replace('"', '*DOUBLEQUOTE*')
                 if not legacy and ',' in binary_string:
                         binary_string = '"' + binary_string + '"'
                 if x == len(element)-1 :

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -333,6 +333,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                 temp_list_b.append(computer_object.operating_system_service_pack)
                 temp_list_b.append(computer_object.operating_system_version)
                 [temp_list_b.append(','.join(map(str, item))) for item in parse_spns(computer_object.service_principal_names)]
+                if not legacy:
+                    temp_list_b.append(computer_object.distinguished_name)
 
                 tmp_element = ''
                 for x, binary_string in enumerate(temp_list_b):
@@ -352,8 +354,6 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                         tmp_element += binary_string + '\t'
                     else:
                         tmp_element += binary_string + ','
-                if not legacy:
-                    temp_list_b.append(computer_object.distinguished_name)
                 computer_information_file.write(tmp_element)
                 _output_dictionary.append(temp_list_a)
 

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -257,7 +257,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
         if not legacy:
             user_information_file.write('SAM Account Name,Status,Locked Out,Distinguished Name,User Password,Display Name,Email,Home Directory,Profile Path,Logon Script Path,Password Last Set,Last Logon,User Comment,Description\n')
         else:
-            user_information_file.write('SAM Account NameStatus\tLocked Out\tDistinguished Name\tUser Password\tDisplay Name\tEmail\tHome Directory\tProfile Path\tLogon Script Path\tPassword Last Set\tLast Logon\tUser Comment\tDescription\n')
+            user_information_file.write('SAM Account NameStatus\tLocked Out\tUser Password\tDisplay Name\tEmail\tHome Directory\tProfile Path\tLogon Script Path\tPassword Last Set\tLast Logon\tUser Comment\tDescription\n')
 
         for user_object in list(users_dictionary.values()):
             if user_object.primary_group_id and user_object.primary_group_id in group_id_to_dn_dictionary:
@@ -293,6 +293,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                         binary_string = binary_string[2:]
                     if binary_string[-1:] == "'":
                         binary_string = binary_string[:-1]
+                    if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
+                        continue
                     if not legacy and ',' in binary_string:
                         binary_string = '"' + binary_string + '"'
                     if x == len(temp_list_a[1:])-1 :
@@ -313,7 +315,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
         if not legacy:
             computer_information_file.write('SAM Account Name,OS,OS Hotfix,OS Service Pack,OS Version,Distinguished Name,SQL SPNs,RA SPNS,Share SPNs,Mail SPNs,Auth SPNs,Backup SPNs,Management SPNs,Other SPNs\n')
         else:
-            computer_information_file.write('SAM Account Name\tOS\tOS Hotfix\tOS Service Pack\tOS Version\tDistinguished Name\tSQL SPNs\tRA SPNS\tShare SPNs\tMail SPNs\tAuth SPNs\tBackup SPNs\tManagement SPNs\tOther SPNs\n')
+            computer_information_file.write('SAM Account Name\tOS\tOS Hotfix\tOS Service Pack\tOS Version\tSQL SPNs\tRA SPNS\tShare SPNs\tMail SPNs\tAuth SPNs\tBackup SPNs\tManagement SPNs\tOther SPNs\n')
 
 
         # TODO: This could create output duplicates. It should be fixed at some point.
@@ -343,6 +345,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                         binary_string = binary_string[2:]
                     if binary_string[-1:] == "'":
                         binary_string = binary_string[:-1]
+                    if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
+                        continue
                     if not legacy and ',' in binary_string:
                         binary_string = '"' + binary_string + '"'
                     if x == len(temp_list_b)-1 :
@@ -363,7 +367,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
         if not legacy:
             group_membership_file.write('Group Name,Member SAM Account Name,Member Status,Group Distinguished Name\n')
         else:
-            group_membership_file.write('Group Name\tMember SAM Account Name\tMember Status\tGroup Distinguished Name\n')
+            group_membership_file.write('Group Name\tMember SAM Account Name\tMember Status\n')
 
         for element in _output_dictionary:
             tmp_element = ''
@@ -373,6 +377,8 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups, query_limit, legac
                     binary_string = binary_string[2:]
                 if binary_string[-1:] == "'":
                     binary_string = binary_string[:-1]
+                if legacy and 'dc=' in binary_string.lower(): # Skip distinguishedName
+                    continue
                 if not legacy and ',' in binary_string:
                         binary_string = '"' + binary_string + '"'
                 if x == len(element)-1 :

--- a/ad-ldap-enum.py
+++ b/ad-ldap-enum.py
@@ -40,23 +40,37 @@ class ADUser(object):
     logon_script = ''
     user_password = ''
 
-    def __init__(self):
-        self.distinguished_name = self.entry_dn
-        self.sam_account_name = self.entry_attributes_as_dict.get('sAMAccountName')[0]
-        self.user_account_control = self.entry_attributes_as_dict.get('userAccountControl')[0]
-        self.primary_group_id = self.entry_attributes_as_dict.get('primaryGroupID')[0]
-        self.comment = self.entry_attributes_as_dict.get('comment')[0].replace('\t', '*TAB*').replace('\r', '*CR*').replace('\n', '*LF*')
-        self.description = self.entry_attributes_as_dict.get('description')[0].replace('\t', '*TAB*').replace('\r', '*CR*').replace('\n', '*LF*')
-        self.homeDirectory = self.entry_attributes_as_dict.get('homeDirectory')[0]
-        self.display_name = self.entry_attributes_as_dict.get('display_name')[0]
-        self.mail = self.entry_attributes_as_dict.get('mail')[0]
-        self.pwdLastSet = self.entry_attributes_as_dict.get('pwdLastSet')[0]
-        self.last_logon = self.entry_attributes_as_dict.get('last_logon')[0]
-        self.profile_path = self.entry_attributes_as_dict.get('profile_path')[0]
-        if self.entry_attributes_as_dict.get('')[0] != '0':
+    def __init__(self, retrieved_attributes):
+        if 'distinguishedName' in retrieved_attributes:
+            self.distinguished_name = retrieved_attributes['distinguishedName'][0]
+        if 'sAMAccountName' in retrieved_attributes:
+            self.sam_account_name = retrieved_attributes['sAMAccountName'][0]
+        if 'userAccountControl' in retrieved_attributes:
+            self.user_account_control = retrieved_attributes['userAccountControl'][0]
+        if 'primaryGroupID' in retrieved_attributes:
+            self.primary_group_id = retrieved_attributes['primaryGroupID'][0]
+        if 'comment' in retrieved_attributes:
+            self.comment = str(retrieved_attributes['comment'][0]).replace("\t", '*TAB*').replace("\r", '*CR*').replace("\n", '*LF*')
+        if 'description' in retrieved_attributes:
+            self.description = str(retrieved_attributes['description'][0]).replace("\t", '*TAB*').replace("\r", '*CR*').replace("\n", '*LF*')
+        if 'homeDirectory' in retrieved_attributes:
+            self.home_directory = retrieved_attributes['homeDirectory'][0]
+        if 'displayName' in retrieved_attributes:
+            self.display_name = retrieved_attributes['displayName'][0]
+        if 'mail' in retrieved_attributes:
+            self.mail = retrieved_attributes['mail'][0]
+        if 'pwdLastSet' in retrieved_attributes:
+            self.password_last_set = retrieved_attributes['pwdLastSet'][0]
+        if 'lastLogon' in retrieved_attributes:
+            self.last_logon = retrieved_attributes['lastLogon'][0]
+        if 'profilePath' in retrieved_attributes:
+            self.profile_path = retrieved_attributes['profilePath'][0]
+        if 'lockoutTime' in retrieved_attributes and retrieved_attributes['lockoutTime'][0] != '0':
             self.locked_out = 'YES'
-        self.scriptPath = self.entry_attributes_as_dict.get('scriptPath')[0]
-        self.userPassword = self.entry_attributes_as_dict.get('userPassword')[0]
+        if 'scriptPath' in retrieved_attributes:
+            self.logon_script = retrieved_attributes['scriptPath'][0]
+        if 'userPassword' in retrieved_attributes:
+            self.user_password = retrieved_attributes['userPassword'][0]
     
     def __str__(self):
         return f"{self.sam_account_name}"
@@ -203,7 +217,7 @@ def ldap_queries(ldap_client, base_dn, explode_nested_groups):
         group_id_to_dn_dictionary[element.entry_attributes_as_dict.get('primaryGroupToken')[0]] = element.entry_dn
         groups_dictionary[element.entry_dn] = element
     #print(groups_dictionary.keys())
-    print(groups_dictionary.items())
+    #print(groups_dictionary.items())
 
     print('[-] Building computers dictionary...')
     for element in computers:
@@ -415,10 +429,11 @@ def query_ldap_with_paging(ldap_client, base_dn, search_filter_custom, attribute
 
     # Append Page to Results
     for element in ldap_client.entries:
+        print(element.entry_raw_attributes)
         if not output_object:
-            output_list.append(element.entry_raw_attributes())
+            output_list.append(element.entry_raw_attributes)
         else:
-            output_list.append(output_object(element.entry_raw_attributes()))
+            output_list.append(output_object(element.entry_raw_attributes))
 
     return output_list
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 argcomplete
 ldap3
+openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-python-ldap
+argcomplete
+ldap3


### PR DESCRIPTION
The following changes were made:
- Changed from `python-ldap` to `ldap3` #27 
- Added `argcomplete` to help with `argparse` file pathing
- Added IPv6 support
- Converted from TSV to CSV
- Added legacy mode to support old TSV output requirements
- Added ldap3 verbosity modes including outputs when binds were not successful #24 
- Added timeout parameters
- Added Pass-the-Hash (PtH) support
- Added logging file support
- Added distinguished name authentication